### PR TITLE
Fix tests to ensure lang settings as expected

### DIFF
--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -158,7 +158,7 @@ def get_cfg_chuks():
 
     nav_en_es_pt = copy.deepcopy(nav_en_es)
     nav_en_es_pt['nav']['nav-pt'] = [{'Início': 'index.md'}]
-    
+
     return {
         'custom_extra_en_es': custom_extra_en_es,
         'custom_extra_en_es_pt': custom_extra_en_es_pt,

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from unittest.mock import patch
 from click.testing import CliRunner
@@ -91,3 +92,85 @@ def build_overrided(
             import traceback
             traceback.print_exception(*result.exc_info)
         return result
+
+
+def get_cfg_chuks():
+
+    custom_extra_en_es = {
+        'custom_extra': {
+            'alternate': [
+                {'name': 'English', 'lang': 'en'},
+                {'name': 'Español', 'lang': 'es'},
+            ],
+            'test_var': '',
+            'test_complex_obj': {'test_var2': '', 'test_var3': ''},
+        }
+    }
+    custom_extra_en_es_pt = copy.deepcopy(custom_extra_en_es)
+    custom_extra_en_es_pt['custom_extra']['alternate'].append(
+        {'name': 'Português', 'lang': 'pt'}
+    )
+
+    site_name_en_es = {
+        'site_name': {
+            'en': 'Collab test',
+            'es': 'Mi test',
+        }
+    }
+    site_name_en_es_pt = copy.deepcopy(site_name_en_es)
+    site_name_en_es_pt['site_name']['pt'] = 'Meu teste'
+
+    copyright_en_es = {
+        'copyright': {
+            'en': 'Copyrigth',
+            'es': 'Derechos de autor',
+        }
+    }
+    copyright_en_es_pt = copy.deepcopy(copyright_en_es)
+    copyright_en_es_pt['copyright']['pt'] = 'Copyrigth'
+
+    site_description_en_es = {
+        'site_description': {
+            'en': 'Descr',
+            'es': 'Descr',
+        }
+    }
+    site_description_en_es_pt = copy.deepcopy(site_description_en_es)
+    site_description_en_es_pt['site_description']['pt'] = 'Descr'
+
+    site_author_en_es = {
+        'site_author': {
+            'en': 'Author',
+            'es': 'Author',
+        }
+    }
+    site_author_en_es_pt = copy.deepcopy(site_author_en_es)
+    site_author_en_es_pt['site_author']['pt'] = 'Author'
+
+    nav_en_es = {
+        'nav': {
+            'nav-en': [{'Home': 'index.md'}],
+            'nav-es': [{'Inicio': 'index.md'}],
+        }
+    }
+    nav_en_es_pt_no_index = copy.deepcopy(nav_en_es)
+    nav_en_es_pt_no_index['nav']['nav-pt'] = [{'Início': 'bad-index.md'}]
+
+    nav_en_es_pt = copy.deepcopy(nav_en_es)
+    nav_en_es_pt['nav']['nav-pt'] = [{'Início': 'index.md'}]
+    
+    return {
+        'custom_extra_en_es': custom_extra_en_es,
+        'custom_extra_en_es_pt': custom_extra_en_es_pt,
+        'site_name_en_es': site_name_en_es,
+        'site_name_en_es_pt': site_name_en_es_pt,
+        'copyright_en_es': copyright_en_es,
+        'copyright_en_es_pt': copyright_en_es_pt,
+        'site_description_en_es': site_description_en_es,
+        'site_description_en_es_pt': site_description_en_es_pt,
+        'site_author_en_es': site_author_en_es,
+        'site_author_en_es_pt': site_author_en_es_pt,
+        'nav_en_es': nav_en_es,
+        'nav_en_es_pt': nav_en_es_pt,
+        'nav_en_es_pt_no_index': nav_en_es_pt_no_index,
+    }

--- a/tests/test_new_lang.py
+++ b/tests/test_new_lang.py
@@ -5,27 +5,23 @@ from run import (
 )
 from helpers_test import (
     build_overrided,
+    get_cfg_chuks,
 )
 
 
 PATHS = get_paths(BASE_FOLDER)
-custom_new_lang_alternate = {
-    'custom_extra': {
-        'alternate': [
-            {'name': 'English', 'lang': 'en'},
-            {'name': 'Español', 'lang': 'es'},
-            {'name': 'Português', 'lang': 'pt'},
-        ],
-        'test_var': '',
-        'test_complex_obj': {'test_var2': '', 'test_var3': ''},
-    },
-}
 
 
 def test_add_new_lang_err_missing_site_name():
     """ Test fail adding new language """
 
-    result = build_overrided(PATHS, override_custom=custom_new_lang_alternate)
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es'],
+    )
+    print(f'OVERRIDE\n{override}')
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Languages in site_name and alternate do not match' in result.exception.args[0]
     assert "['en', 'es'] != ['en', 'es', 'pt']" in result.exception.args[0]
@@ -34,15 +30,13 @@ def test_add_new_lang_err_missing_site_name():
 def test_add_new_lang_err_missing_alternate():
     """ Test fail adding new language """
 
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        }
-    }
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es'],
+        **cfg_chunks['site_name_en_es_pt'],
+    )
 
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Languages in site_name and alternate do not match' in result.exception.args[0]
     assert "['en', 'es', 'pt'] != ['en', 'es']" in result.exception.args[0]
@@ -52,16 +46,14 @@ def test_add_new_lang_err_missing_lang_copyright():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        }
-    }
-    overrides.update(custom_new_lang_alternate)
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es'],
+    )
 
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Language "pt" not found for setting "copyright" in config' in result.exception.args[0]
 
@@ -70,21 +62,15 @@ def test_add_new_lang_err_missing_lang_description():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        }
-    }
-    overrides.update(custom_new_lang_alternate)
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es'],
+    )
 
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Language "pt" not found for setting "site_description" in config' in result.exception.args[0]
 
@@ -93,26 +79,16 @@ def test_add_new_lang_err_missing_lang_site_author():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        },
-        'site_description': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        }
-    }
-    overrides.update(custom_new_lang_alternate)
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es_pt'],
+        **cfg_chunks['site_author_en_es'],
+    )
 
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Language "pt" not found for setting "site_author" in config' in result.exception.args[0]
 
@@ -121,31 +97,16 @@ def test_add_new_lang_err_missing_lang_nav():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        },
-        'site_description': {
-            'en': 'description',
-            'es': 'description',
-            'pt': 'description',
-        },
-        'site_author': {
-            'en': 'author',
-            'es': 'author',
-            'pt': 'author',
-        }
-    }
-    overrides.update(custom_new_lang_alternate)
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es_pt'],
+        **cfg_chunks['site_author_en_es_pt'],
+    )
 
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'No "nav-pt" sub-section found in the "nav" section from your custom config file' in result.exception.args[0]
 
@@ -154,38 +115,17 @@ def test_add_new_lang_err_missing_lang_nav_index():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        },
-        'site_description': {
-            'en': 'description',
-            'es': 'description',
-            'pt': 'description',
-        },
-        'site_author': {
-            'en': 'author',
-            'es': 'author',
-            'pt': 'author',
-        },
-        'nav': {
-            'nav-en': [{'Home': 'index.md'}],
-            'nav-es': [{'Inicio': 'index.md'}],
-            # at leat one index.md is required
-            'nav-pt': [{'Inicio': 'no-index.md'}],
-        }
-    }
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es_pt'],
+        **cfg_chunks['site_author_en_es_pt'],
+        **cfg_chunks['nav_en_es_pt_no_index'],
+    )
 
-    overrides.update(custom_new_lang_alternate)
-
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'No "index.md" found in the "nav-pt" sub-section from your custom config file' in result.exception.args[0]
 
@@ -194,37 +134,17 @@ def test_add_new_lang_err_missing_lang_docs_folder():
     """ Test fail adding new language """
 
     # Override site names and alternates with PT
-    overrides = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        },
-        'site_description': {
-            'en': 'description',
-            'es': 'description',
-            'pt': 'description',
-        },
-        'site_author': {
-            'en': 'author',
-            'es': 'author',
-            'pt': 'author',
-        },
-        'nav': {
-            'nav-en': [{'Home': 'index.md'}],
-            'nav-es': [{'Inicio': 'index.md'}],
-            'nav-pt': [{'Inicio': 'index.md'}],
-        }
-    }
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es_pt'],
+        **cfg_chunks['site_author_en_es_pt'],
+        **cfg_chunks['nav_en_es_pt'],
+    )
 
-    overrides.update(custom_new_lang_alternate)
-
-    result = build_overrided(PATHS, override_custom=overrides)
+    result = build_overrided(PATHS, override_custom=override)
     assert result.exit_code == 1
     assert 'Docs folder not found' in result.exception.args[0]
     assert '/docs/docs-pt' in result.exception.args[0]
@@ -233,40 +153,20 @@ def test_add_new_lang_err_missing_lang_docs_folder():
 def test_add_new_lang_OK():
     """ Test OK adding new language """
 
-    override_custom = {
-        'site_name': {
-            'en': 'My site name',
-            'es': 'Mi sitio',
-            'pt': 'Meu site',
-        },
-        'copyright': {
-            'en': 'Copyrigth',
-            'es': 'Copyrigth',
-            'pt': 'Copyrigth',
-        },
-        'site_description': {
-            'en': 'description',
-            'es': 'description',
-            'pt': 'description',
-        },
-        'site_author': {
-            'en': 'author',
-            'es': 'author',
-            'pt': 'author',
-        },
-        'nav': {
-            'nav-en': [{'Home': 'index.md'}],
-            'nav-es': [{'Inicio': 'index.md'}],
-            'nav-pt': [{'Inicio': 'index.md'}],
-        },
-    }
+    cfg_chunks = get_cfg_chuks()
+    override = dict(
+        **cfg_chunks['custom_extra_en_es_pt'],
+        **cfg_chunks['site_name_en_es_pt'],
+        **cfg_chunks['copyright_en_es_pt'],
+        **cfg_chunks['site_description_en_es_pt'],
+        **cfg_chunks['site_author_en_es_pt'],
+        **cfg_chunks['nav_en_es_pt'],
+    )
 
     docs_test_folder = '../test-folder'
     override_base = {
         'docs_dir': docs_test_folder,
     }
-
-    override_custom.update(custom_new_lang_alternate)
 
     # Create a test folder will all language index files
     Path(docs_test_folder).mkdir(exist_ok=True)
@@ -277,6 +177,6 @@ def test_add_new_lang_OK():
     Path(docs_test_folder + '/docs-pt').mkdir(exist_ok=True)
     Path(docs_test_folder + '/docs-pt/index.md').touch()
 
-    result = build_overrided(PATHS, override_custom=override_custom, override_base=override_base)
+    result = build_overrided(PATHS, override_custom=override, override_base=override_base)
 
     assert result.exit_code == 0


### PR DESCRIPTION
If a client of this template already use a third language test will fail
Ensure setting are defined as required